### PR TITLE
Call C++ function from QML. Works with qDebug() not cout.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,13 +50,20 @@ int main(int argc, char *argv[]) {
     parser.process(app);
     aboutData.processCommandLine(&parser);
     
+    // Did not work
+    /*
     MyClass myClass;
     qmlRegisterType<MyClass>("i.did.it.myclass", 0, 1, "MyClass");
     
-    QQmlApplicationEngine engine;
-    
     QQmlContext* context = new QQmlContext(engine.rootContext());
     context->setContextProperty("MyClass", &myClass);
+    */
+    
+    QScopedPointer<MyClass> myClass(new MyClass);
+    
+    QQmlApplicationEngine engine;
+    
+    engine.rootContext()->setContextProperty("myClass", myClass.data());
     
     engine.load(QUrl(QStringLiteral("qrc:/UI/main.qml"))); //qrc:{not the actual path rather it is the file as referenced in the resources.qrc file}
     

--- a/src/qml/UI/MainPage.qml
+++ b/src/qml/UI/MainPage.qml
@@ -67,7 +67,7 @@ Kirigami.Page {
                 print(firstTextField.text);
                 print(this.text);
                 getText.clickedButton("Hello from QML");
-                MyClass.printStuff();
+                myClass.test();
             }
         }
         QQC2.Button {

--- a/src/qml/UI/main.qml
+++ b/src/qml/UI/main.qml
@@ -3,7 +3,7 @@ import QtQuick.Layouts 1.12
 import QtQuick.Controls 2.12 as QQC2
 import org.kde.kirigami 2.10 as Kirigami
 
-import i.did.it.myclass 0.1 // Not yet. Everybody and all the tutorials are lying to you and now you have to figure it out all by yourself or build your own toolkit
+// import i.did.it.myclass 0.1 // Not yet. Everybody and all the tutorials are lying to you and now you have to figure it out all by yourself or build your own toolkit
 
 Kirigami.ApplicationWindow {
     id: root


### PR DESCRIPTION
Called a test function from a C++ class in QML without using qmlRegisterType. However, I could only use qDebug which is part of Qt and not using cout (the C++ way). Need more information. I at least got something to print out from a C++ class when pressing a button in a QML gui. After FOUR MONTHS of work. Now I need to wast more time and energy going through more tutorials, that fail and do nothing but wast more of my time and for some reason cannot be applied to cases with more than one QML file (therefore leading to thinking all QML should be in one file thus making it unmaintainable), before FINALLY getting a c++ class to output something or do C++ functions by pressing a QML button.